### PR TITLE
Fix: Harden against XSS vulnerabilities

### DIFF
--- a/index.php
+++ b/index.php
@@ -99,7 +99,7 @@ else {
       var PageRefresh;
       
       function ReloadPage() {
-         $.get("./index.php'.(isset($_GET['show'])?'?show='.$_GET['show']:'').'", function(data) {
+         $.get("./index.php'.(isset($_GET['show'])?'?show='.htmlspecialchars($_GET['show'], ENT_QUOTES, 'UTF-8'):'').'", function(data) {
             var BodyStart = data.indexOf("<bo"+"dy");
             var BodyEnd = data.indexOf("</bo"+"dy>");
             if ((BodyStart >= 0) && (BodyEnd > BodyStart)) {

--- a/pgs/modules.php
+++ b/pgs/modules.php
@@ -33,7 +33,7 @@ for ($i = 1; $i <= $NumberOfModules; $i++) {
    echo '
  <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
    <td align="center">'. $module .'</td>
-   <td align="center">'. (empty($PageOptions['ModuleNames'][$module]) ? '-' : $PageOptions['ModuleNames'][$module]) .'</td>
+   <td align="center">'. (empty($PageOptions['ModuleNames'][$module]) ? '-' : htmlspecialchars($PageOptions['ModuleNames'][$module], ENT_QUOTES, 'UTF-8')) .'</td>
    <td align="center">'. count($Reflector->GetNodesInModulesByID($module)) .'</td>
    <td align="center">'. 'REF' . $ReflectorNumber . $module . 'L' .'</td>
    <td align="center">'. (is_numeric($ReflectorNumber) ? '*' . sprintf('%01d',$ReflectorNumber) . (($i<=4)?$module:sprintf('%02d',$i)) : '-') .'</td>

--- a/pgs/peers.php
+++ b/pgs/peers.php
@@ -54,16 +54,16 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    }
    if ($Result && (trim($URL) != "")) {
       echo '
-   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'" style="text-decoration:none;color:#000000;">'.$Name.'</a></td>';
+   <td><a href="'.htmlspecialchars($URL, ENT_QUOTES, 'UTF-8').'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.htmlspecialchars($Name, ENT_QUOTES, 'UTF-8').'" style="text-decoration:none;color:#000000;">'.htmlspecialchars($Name, ENT_QUOTES, 'UTF-8').'</a></td>';
    } else {
       echo '
-   <td>'.$Name.'</td>';
+   <td>'.htmlspecialchars($Name, ENT_QUOTES, 'UTF-8').'</td>';
    }
    echo '
    <td>'.date("d.m.Y H:i", $Reflector->Peers[$i]->GetLastHeardTime()).'</td>
    <td>'.FormatSeconds(time()-$Reflector->Peers[$i]->GetConnectTime()).' s</td>
-   <td align="center">'.$Reflector->Peers[$i]->GetProtocol().'</td>
-   <td align="center">'.$Reflector->Peers[$i]->GetLinkedModule().'</td>';
+   <td align="center">'.htmlspecialchars($Reflector->Peers[$i]->GetProtocol(), ENT_QUOTES, 'UTF-8').'</td>
+   <td align="center">'.htmlspecialchars($Reflector->Peers[$i]->GetLinkedModule(), ENT_QUOTES, 'UTF-8').'</td>';
    if ($PageOptions['PeerPage']['IPModus'] != 'HideIP') {
       echo '
    <td>';
@@ -73,7 +73,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
             case 'ShowLast1ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[3]; break;
             case 'ShowLast2ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[2].'.'.$Bytes[3]; break;
             case 'ShowLast3ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[1].'.'.$Bytes[2].'.'.$Bytes[3]; break;
-            default                       : echo $Reflector->Peers[$i]->GetIP();
+            default                       : echo htmlspecialchars($Reflector->Peers[$i]->GetIP(), ENT_QUOTES, 'UTF-8');
          }
       }
       echo '</td>';

--- a/pgs/reflectors.php
+++ b/pgs/reflectors.php
@@ -41,10 +41,10 @@ for ($i=0;$i<count($Reflectors);$i++) {
    echo '
  <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
    <td align="center">'.($i+1).'</td>
-   <td><a href="'.$DASHBOARDURL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$NAME.'">'.$NAME.'</a></td>
-   <td>'.$COUNTRY.'</td>
+   <td><a href="'.htmlspecialchars($DASHBOARDURL, ENT_QUOTES, 'UTF-8').'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.htmlspecialchars($NAME, ENT_QUOTES, 'UTF-8').'">'.htmlspecialchars($NAME, ENT_QUOTES, 'UTF-8').'</a></td>
+   <td>'.htmlspecialchars($COUNTRY, ENT_QUOTES, 'UTF-8').'</td>
    <td align="center" valign="middle"><img src="./img/'; if ($LASTCONTACT<(time()-1800)) { echo 'down'; } ELSE { echo 'up'; } echo '.png" height="25" /></td>
-   <td>'.$COMMENT.'</td>
+   <td>'.htmlspecialchars($COMMENT, ENT_QUOTES, 'UTF-8').'</td>
  </tr>';
 }
 

--- a/pgs/users.php
+++ b/pgs/users.php
@@ -10,30 +10,30 @@ if (!isset($_SESSION['FilterModule'])) {
 
 if (isset($_POST['do'])) {
    if ($_POST['do'] == 'SetFilter') {
-      
+
       if (isset($_POST['txtSetCallsignFilter'])) {
          $_POST['txtSetCallsignFilter'] = trim($_POST['txtSetCallsignFilter']);
          if ($_POST['txtSetCallsignFilter'] == "") {
             $_SESSION['FilterCallSign'] = null;
          }
          else {
-            $_SESSION['FilterCallSign'] = $_POST['txtSetCallsignFilter'];
+            $_SESSION['FilterCallSign'] = htmlspecialchars($_POST['txtSetCallsignFilter'], ENT_QUOTES, 'UTF-8');
             if (strpos($_SESSION['FilterCallSign'], "*") === false) {
                $_SESSION['FilterCallSign'] = "*".$_SESSION['FilterCallSign']."*";
             }
          }
-         
+
       }
-      
+
       if (isset($_POST['txtSetModuleFilter'])) {
          $_POST['txtSetModuleFilter'] = trim($_POST['txtSetModuleFilter']);
          if ($_POST['txtSetModuleFilter'] == "") {
             $_SESSION['FilterModule'] = null;
          }
          else {
-            $_SESSION['FilterModule'] = $_POST['txtSetModuleFilter'];
+            $_SESSION['FilterModule'] = htmlspecialchars($_POST['txtSetModuleFilter'], ENT_QUOTES, 'UTF-8');
          }
-         
+
       }
    }
 }
@@ -44,16 +44,16 @@ if (isset($_GET['do'])) {
       $_SESSION['FilterCallSign'] = null;
    }
 }
-   
+
 
 ?>
 <table border="0">
    <tr>
       <td  valign="top">
-         
+
 
 <table class="listingtable"><?php
-  
+
 if ($PageOptions['UserPage']['ShowFilter']) {
    echo '
  <tr>
@@ -63,19 +63,19 @@ if ($PageOptions['UserPage']['ShowFilter']) {
             <td align="left">
                <form name="frmFilterCallSign" method="post" action="./index.php">
                   <input type="hidden" name="do" value="SetFilter" />
-                  <input type="text" class="FilterField" value="'.$_SESSION['FilterCallSign'].'" name="txtSetCallsignFilter" placeholder="Callsign" onfocus="SuspendPageRefresh();" onblur="setTimeout(ReloadPage, '.$PageOptions['PageRefreshDelay'].');" />
+                  <input type="text" class="FilterField" value="'.htmlspecialchars((string)$_SESSION['FilterCallSign'], ENT_QUOTES, 'UTF-8').'" name="txtSetCallsignFilter" placeholder="Callsign" onfocus="SuspendPageRefresh();" onblur="setTimeout(ReloadPage, '.$PageOptions['PageRefreshDelay'].');" />
                   <input type="submit" value="Apply" class="FilterSubmit" />
                </form>
             </td>';
-   if (($_SESSION['FilterModule'] != null) || ($_SESSION['FilterCallSign'] != null)) {               
+   if (($_SESSION['FilterModule'] != null) || ($_SESSION['FilterCallSign'] != null)) {
       echo '
          <td><a href="./index.php?do=resetfilter" class="smalllink">Disable filters</a></td>';
-   }  
-   echo '            
+   }
+   echo '
             <td align="right" style="padding-right:3px;">
                <form name="frmFilterModule" method="post" action="./index.php">
                   <input type="hidden" name="do" value="SetFilter" />
-                  <input type="text" class="FilterField" value="'.$_SESSION['FilterModule'].'" name="txtSetModuleFilter" placeholder="Module" onfocus="SuspendPageRefresh();" onblur="setTimeout(ReloadPage, '.$PageOptions['PageRefreshDelay'].');" />
+                  <input type="text" class="FilterField" value="'.htmlspecialchars((string)$_SESSION['FilterModule'], ENT_QUOTES, 'UTF-8').'" name="txtSetModuleFilter" placeholder="Module" onfocus="SuspendPageRefresh();" onblur="setTimeout(ReloadPage, '.$PageOptions['PageRefreshDelay'].');" />
                   <input type="submit" value="Apply" class="FilterSubmit" />
                </form>
             </td>
@@ -83,10 +83,10 @@ if ($PageOptions['UserPage']['ShowFilter']) {
    </th>
 </tr>';
 }
-                
-   
-?>   
- <tr>   
+
+
+?>
+ <tr>
    <th>#</th>
    <th>Flag</th>
    <th>Callsign</th>
@@ -114,12 +114,12 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
             $MO = false;
          }
       }
-      
+
       $ShowThisStation = ($CS && $MO);
    }
-      
-      
-   if ($ShowThisStation) {   
+
+
+   if ($ShowThisStation) {
       if ($odd == "#FFFFFF") { $odd = "#F1FAFA"; } else { $odd = "#FFFFFF"; }
       echo '
   <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
@@ -130,65 +130,65 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
       else {
          echo ($i+1);
       }
-   
-   
+
+
       echo '</td>
    <td align="center" width="60">';
-   
+
       list ($Flag, $Name) = $Reflector->GetFlag($Reflector->Stations[$i]->GetCallSign());
       if (file_exists("./img/flags/".$Flag.".png")) {
-         echo '<a href="#" class="tip"><img src="./img/flags/'.$Flag.'.png" height="15" alt="'.$Name.'" /><span>'.$Name.'</span></a>';
+         echo '<a href="#" class="tip"><img src="./img/flags/'.htmlspecialchars($Flag, ENT_QUOTES, 'UTF-8').'.png" height="15" alt="'.htmlspecialchars($Name, ENT_QUOTES, 'UTF-8').'" /><span>'.htmlspecialchars($Name, ENT_QUOTES, 'UTF-8').'</span></a>';
       }
       echo '</td>
-   <td width="75"><a href="https://www.qrz.com/db/'.$Reflector->Stations[$i]->GetCallsignOnly().'" class="pl" target="_blank">'.$Reflector->Stations[$i]->GetCallsignOnly().'</a></td>
-   <td width="60">'.$Reflector->Stations[$i]->GetSuffix().'</td>
-   <td width="50" align="center"><a href="http://www.aprs.fi/'.$Reflector->Stations[$i]->GetCallsignOnly().'" class="pl" target="_blank"><img src="./img/sat.png" /></a></td>
-   <td width="150">'.$Reflector->Stations[$i]->GetVia();
+   <td width="75"><a href="https://www.qrz.com/db/'.htmlspecialchars($Reflector->Stations[$i]->GetCallsignOnly(), ENT_QUOTES, 'UTF-8').'" class="pl" target="_blank">'.htmlspecialchars($Reflector->Stations[$i]->GetCallsignOnly(), ENT_QUOTES, 'UTF-8').'</a></td>
+   <td width="60">'.htmlspecialchars($Reflector->Stations[$i]->GetSuffix(), ENT_QUOTES, 'UTF-8').'</td>
+   <td width="50" align="center"><a href="http://www.aprs.fi/'.htmlspecialchars($Reflector->Stations[$i]->GetCallsignOnly(), ENT_QUOTES, 'UTF-8').'" class="pl" target="_blank"><img src="./img/sat.png" /></a></td>
+   <td width="150">'.htmlspecialchars($Reflector->Stations[$i]->GetVia(), ENT_QUOTES, 'UTF-8');
       if ($Reflector->Stations[$i]->GetPeer() != $Reflector->GetReflectorName()) {
-         echo ' / '.$Reflector->Stations[$i]->GetPeer();
+         echo ' / '.htmlspecialchars($Reflector->Stations[$i]->GetPeer(), ENT_QUOTES, 'UTF-8');
       }
       echo '</td>
    <td width="150">'.@date("d.m.Y H:i", $Reflector->Stations[$i]->GetLastHeardTime()).'</td>
-   <td align="center" width="30">'.$Reflector->Stations[$i]->GetModule().'</td>
+   <td align="center" width="30">'.htmlspecialchars($Reflector->Stations[$i]->GetModule(), ENT_QUOTES, 'UTF-8').'</td>
  </tr>';
    }
    if ($i == $PageOptions['LastHeardPage']['LimitTo']) { $i = $Reflector->StationCount()+1; }
 }
 
-?> 
- 
+?>
+
 </table>
 
 
 </td>
 <td style="padding-left:50px;" align="center" valign="top">
-   
-   
+
+
 
 
 <table class="listingtable">
-<?php 
+<?php
 
 $Modules = $Reflector->GetModules();
 sort($Modules, SORT_STRING);
 echo '
  <tr>';
 for ($i=0;$i<count($Modules);$i++) {
-   
+
    if (isset($PageOptions['ModuleNames'][$Modules[$i]])) {
       echo '
-   
-      <th>'.$PageOptions['ModuleNames'][$Modules[$i]];
+
+      <th>'.htmlspecialchars($PageOptions['ModuleNames'][$Modules[$i]], ENT_QUOTES, 'UTF-8');
       if (trim($PageOptions['ModuleNames'][$Modules[$i]]) != "") {
          echo '<br />';
       }
-      echo $Modules[$i].'</th>
+      echo htmlspecialchars($Modules[$i], ENT_QUOTES, 'UTF-8').'</th>
 ';
    }
    else {
    echo '
-  
-      <th>'.$Modules[$i].'</th>';
+
+      <th>'.htmlspecialchars($Modules[$i], ENT_QUOTES, 'UTF-8').'</th>';
    }
 }
 
@@ -203,25 +203,25 @@ for ($i=0;$i<count($Modules);$i++) {
    $Users = $Reflector->GetNodesInModulesByID($Modules[$i]);
    echo '
    <td valign="top" style="border:0px;padding:0px;">
-   
+
       <table width="100" border="0" style="padding:0px;margin:0px;">';
    $odd = "";
-   
+
    $UserCheckedArray = array();
-   
+
    for ($j=0;$j<count($Users);$j++) {
-      
+
       if ($odd == "#FFFFFF") { $odd = "#F1FAFA"; } else { $odd = "#FFFFFF"; }
       $Displayname = $Reflector->GetCallsignAndSuffixByID($Users[$j]);
       echo '
             <tr height="25" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
-               <td valign="top" style="border-bottom:1px #C1DAD7 solid;"><a href="http://www.aprs.fi/'.$Displayname.'" class="pl" target="_blank">'.$Displayname.'</a> </td>
+               <td valign="top" style="border-bottom:1px #C1DAD7 solid;"><a href="http://www.aprs.fi/'.htmlspecialchars($Displayname, ENT_QUOTES, 'UTF-8').'" class="pl" target="_blank">'.htmlspecialchars($Displayname, ENT_QUOTES, 'UTF-8').'</a> </td>
             </tr>';
       $UserCheckedArray[] = $Users[$j];
    }
    echo '
       </table>
-   
+
    </td>';
 }
 
@@ -229,9 +229,9 @@ echo '
 </tr>';
 
 ?>
-</table>    
+</table>
 
 
 </td>
 </tr>
-</table>     
+</table>


### PR DESCRIPTION
This commit addresses several potential cross-site scripting (XSS) vulnerabilities by applying input sanitization and output encoding throughout the application.

Changes made:

- In `pgs/users.php`:
    - Sanitized `$_POST['txtSetCallsignFilter']` and `$_POST['txtSetModuleFilter]` using `htmlspecialchars()` before storing them in session variables.
    - Ensured `$_SESSION['FilterCallSign']` and `$_SESSION['FilterModule']` are escaped with `htmlspecialchars()` before being displayed in input fields.
    - Encoded various dynamic outputs (call signs, suffixes, peer info, module names, etc.) using `htmlspecialchars()` to prevent XSS from station and module data. This required several attempts for one specific code block, ultimately resolved by replacing the entire file content with a fully sanitized version.

- In `pgs/peers.php`:
    - Encoded peer names, IPs, protocols, linked modules, and URLs (from external XML) using `htmlspecialchars()` before display.

- In `pgs/reflectors.php`:
    - Encoded reflector names, countries, comments, and dashboard URLs (from external XML) using `htmlspecialchars()` before display.

- In `index.php`:
    - Sanitized the `$_GET['show']` parameter using `htmlspecialchars()` where it's used in a JavaScript string for AJAX page refreshes.

- In `pgs/modules.php`:
    - Encoded `$PageOptions['ModuleNames'][$module]` (sourced from config) using `htmlspecialchars()` before display for defense-in-depth.

A review of other files (class definitions, and pages embedding external iframes or generating data that appeared safe) did not reveal further direct XSS vectors within the scope of this application's codebase.